### PR TITLE
Add double buffering and general code improvements

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AudioZero
-version=1.1.1
+version=1.2.0
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Allows playing audio files from an SD card. For Arduino Zero and MKR1000 only.

--- a/src/AudioZero.cpp
+++ b/src/AudioZero.cpp
@@ -16,40 +16,39 @@
 #include "wav.h"
 
 #define NEUTRAL_SOUND 512 // = (2^10 / 2)
-#define NUMBER_OF_SAMPLES 1024 // Number of samples to read in block
+#define NUMBER_OF_SAMPLES 512 // Number of samples to read in block
 
 /* Global variables */
-volatile bool __StartFlag; // Is started?
-volatile uint32_t __SampleIndex; // current played sample
-uint32_t __HeadIndex; // current start of buffer
-volatile uint32_t __StopAtIndex; // Sample where to stop writing buffer into DAC
-
 volatile uint32_t __samples_callback;
 volatile uint32_t __samples_next_callback;
+volatile bool __callback_due;
 void (*__callback)(void);
 
-int16_t *__WavSamples; // buffer
-riff_header *__RIFFHeader; // RIFF header
-wav_header *__WavHeader; // Wav header
-data_header *__DataHeader; // Wav header
-uint32_t __SamplesPending;
+volatile int16_t __buffer1[NUMBER_OF_SAMPLES];
+volatile int16_t __buffer2[NUMBER_OF_SAMPLES];
+
+volatile int16_t *__front_buffer = __buffer1;
+volatile int16_t *__back_buffer = __buffer2;
+
+volatile size_t __buffer1_len = 0;
+volatile size_t __buffer2_len = 0;
+
+volatile size_t *__front_buffer_len = &__buffer1_len;
+volatile size_t *__back_buffer_len = &__buffer2_len;
+
+volatile bool __buffer_swap_required = false;
+volatile size_t __front_buffer_pos = 0;
+
+riff_header __RIFFHeader; // RIFF header
+wav_header __WavHeader; // Wav header
+data_header __DataHeader; // Wav header
 unsigned int __TotalSamples;
 
 AudioZeroSource *__toPlay;
-bool __Configured = false;
+bool __TcConfigured = false;
 
 void AudioZeroClass::begin() {
-    __StartFlag = false;
-    __SampleIndex = 0;			//in order to start from the beginning
-    __StopAtIndex = -1;
-    __SamplesPending = 0;
     __TotalSamples = 0;
-
-    /*Allocate the buffer where the samples are stored*/
-    __WavSamples = (int16_t *) malloc(NUMBER_OF_SAMPLES * sizeof(int16_t));
-    __RIFFHeader = (riff_header *) malloc(RIFF_HEADER_SIZE);
-    __WavHeader = (wav_header *) malloc(WAV_HEADER_SIZE);
-    __DataHeader = (data_header *) malloc(DATA_HEADER_SIZE);
 
     /*Set callback to none */
     __samples_callback = 0;
@@ -58,20 +57,14 @@ void AudioZeroClass::begin() {
 
     /*Modules configuration */
     dacConfigure();
-
-
 }
 
 void AudioZeroClass::end() {
-    if (__Configured) {
+    if (__TcConfigured) {
         tcDisable();
         tcReset();
     }
-    analogWrite(A0, 0);
-    free(__WavSamples);
-    free(__RIFFHeader);
-    free(__WavHeader);
-    free(__DataHeader);
+    analogWrite(A0, NEUTRAL_SOUND);
 }
 
 
@@ -80,39 +73,31 @@ unsigned int AudioZeroClass::getNumSamples() {
 }
 
 unsigned int AudioZeroClass::getSampleRate() {
-    return __WavHeader->sample_rate;
+    return __WavHeader.sample_rate;
 }
 
 int AudioZeroClass::prepare(AudioZeroSource& toPlay){
-    __StartFlag = false; // to stop writing from the buffer
-    __SampleIndex = 0;	//in order to start from the beginning
-    __StopAtIndex = -1;
-    __SamplesPending = 0;
     __toPlay = &toPlay;
 
     // Read header + first buffer
-    int to_read = 0;
     int available = __toPlay->available();
 
     if (available > 0) {
         // READ RIFF Header
-        __toPlay->read(__RIFFHeader, RIFF_HEADER_SIZE);
+        __toPlay->read(&__RIFFHeader, RIFF_HEADER_SIZE);
 
         // Read WAV Header
-        __toPlay->read(__WavHeader, WAV_HEADER_SIZE);
+        __toPlay->read(&__WavHeader, WAV_HEADER_SIZE);
 
-        tcConfigure(__WavHeader->sample_rate);
-        __toPlay->seek(RIFF_HEADER_SIZE + __WavHeader->data_header_length + 8);
+        tcConfigure(__WavHeader.sample_rate);
+        __toPlay->seek(RIFF_HEADER_SIZE + __WavHeader.data_header_length + 8);
 
-        __toPlay->read(__DataHeader, DATA_HEADER_SIZE);
-        __SamplesPending = __DataHeader->data_length / 2;
-        __TotalSamples = __SamplesPending;
+        __toPlay->read(&__DataHeader, DATA_HEADER_SIZE);
+        __TotalSamples = __DataHeader.data_length / sizeof(uint16_t);
 
-        to_read = NUMBER_OF_SAMPLES;
-        __toPlay->read(__WavSamples, to_read  * sizeof(int16_t));
-        __HeadIndex = 0;
-        __SamplesPending -= to_read;
-        tcStartCounter(); //start the interruptions, it will do nothing until __StartFlag is true
+        __buffer_swap_required = true;
+
+        tcStartCounter(); //start the interruptions
         return 0;
     } else {
         return -1; // File is empty
@@ -120,65 +105,59 @@ int AudioZeroClass::prepare(AudioZeroSource& toPlay){
 }
 
 void AudioZeroClass::play() {
-    int to_read = 0;
-    int available = 0;
-    __StartFlag = true;
-    while (!__toPlay->abort() && (available = __toPlay->available()) && __SamplesPending > 0) {
-        uint32_t current__SampleIndex = __SampleIndex;
 
-        if (current__SampleIndex > __HeadIndex) {
-            to_read = min(current__SampleIndex - __HeadIndex, __SamplesPending);
-            if (to_read > 0) { // First time this will be 0
-                if (to_read > available) {
-                    // If we have less bytes to read, read the missing and stop
-                    to_read = available;
-                }
-                __toPlay->read(&__WavSamples[__HeadIndex], to_read * sizeof(int16_t));
-                __SamplesPending -= to_read;
-                __StopAtIndex = to_read + __HeadIndex-1;
-                __HeadIndex = current__SampleIndex;
-            }
-        } else if (current__SampleIndex < __HeadIndex) {
-            to_read = min(NUMBER_OF_SAMPLES-1 - __HeadIndex, __SamplesPending);
-            if (to_read > 0) {
-                if (to_read > available) {
-                    // If we have less bytes to read, read the missing and stop
-                    to_read = available;
-                    __StopAtIndex = to_read + __HeadIndex - 1;
-                } else {
-                    // If not, we have less bytes available
-                    available -= to_read;
-                }
-                __toPlay->read(&__WavSamples[__HeadIndex], to_read  * sizeof(int16_t));
-                __SamplesPending -= to_read;
-                if (available > 0) {
-                    to_read = min(current__SampleIndex, __SamplesPending);
-                    if (to_read > 0) {
-                        if (to_read > available) {
-                            // If we have less bytes to read, read the missing and stop
-                            to_read = available;
-                        }
-                        __toPlay->read(__WavSamples, to_read  * sizeof(int16_t));
-                        __SamplesPending -= to_read;
-                        __StopAtIndex = to_read - 1;
-                    }
-                }
-                __HeadIndex = current__SampleIndex;
+    while (!__toPlay->abort() && __toPlay->available()) {
+
+        // Read our file into our back buffer
+        int bytes_read = __toPlay->read((void*) __back_buffer, NUMBER_OF_SAMPLES * sizeof(uint16_t));
+        *__back_buffer_len = bytes_read / sizeof(uint16_t);
+
+        if (*__back_buffer_len == 0)
+            break; // EOF
+
+        // Wait for the currently playing buffer
+        while (!__buffer_swap_required)
+        {
+            if (__callback_due) {
+                __callback_due = false;
+                if (__callback)
+                    __callback();
             }
         }
-    }
-    // Serial.println(__SampleIndex);
-    // Serial.println(__StopAtIndex);
 
-    if (__toPlay->abort()) {
-        tcDisable();
-    } else {
-        while (__SampleIndex != __StopAtIndex) {
-            delay(1);
+        // Disable interrupts
+        noInterrupts();
+
+        // Swap the buffers
+        volatile int16_t *temp_buffer = __front_buffer;
+        __front_buffer = __back_buffer;
+        __back_buffer = temp_buffer;
+
+        volatile size_t *temp_buffer_len = __front_buffer_len;
+        __front_buffer_len = __back_buffer_len;
+        __back_buffer_len = temp_buffer_len;
+
+        // Reset the front buffer position
+        __front_buffer_pos = 0;
+
+        // Clear the buffer swap required flag
+        __buffer_swap_required = false;
+
+        // Re-enable interrupts
+        interrupts();
+
+    }
+    
+    // Wait for the final buffer completion
+    while (!__buffer_swap_required)
+    {
+        if (__callback_due) {
+            __callback_due = false;
+            if (__callback)
+                __callback();
         }
     }
 }
-
 
 /**
  * Configures the DAC in event triggered mode.
@@ -198,7 +177,7 @@ void AudioZeroClass::dacConfigure(void) {
  * each time the audio sample frequency period expires.
  */
  void AudioZeroClass::tcConfigure(uint32_t sampleRate) {
-     __Configured = true;
+    __TcConfigured = true;
     // Enable GCLK for TCC2 and TC5 (timer counter input clock)
     GCLK->CLKCTRL.reg = (uint16_t) (GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | GCLK_CLKCTRL_ID(GCM_TC4_TC5)) ;
     while (GCLK->STATUS.bit.SYNCBUSY);
@@ -226,7 +205,6 @@ void AudioZeroClass::dacConfigure(void) {
     TC5->COUNT16.INTENSET.bit.MC0 = 1;
     while (tcIsSyncing());
 }
-
 
 bool AudioZeroClass::tcIsSyncing() {
     return TC5->COUNT16.STATUS.reg & TC_STATUS_SYNCBUSY;
@@ -264,29 +242,32 @@ extern "C" {
 #endif
 
 void Audio_Handler (void) {
-    // Write next sample
-    if ((__SampleIndex != __StopAtIndex) && __StartFlag != false) {
-        analogWrite(A0, (__WavSamples[__SampleIndex++] >> 6) + 512);
-        if (__samples_callback != 0) {
-            __samples_next_callback--;
-            if (__samples_next_callback == 0 ) {
-                __callback();
-                __samples_next_callback = __samples_callback;
-            }
-        }
-    } else {
-        analogWrite(A0, NEUTRAL_SOUND);
-    }
 
-    // Clear interrupt
+    // Clear our interrupt flag
     TC5->COUNT16.INTFLAG.bit.MC0 = 1;
-    // If it was the last sample in the buffer, start again
-    if (__SampleIndex == NUMBER_OF_SAMPLES - 1) {
-        __SampleIndex = 0;
+
+    // Process the front buffer
+    if (__buffer_swap_required)
+        return;
+
+    uint16_t data = (uint16_t) __front_buffer[__front_buffer_pos++];
+    data >>= 6; // Convert from 16 bit to 10 bit
+    data += 512; // Center the data
+    analogWrite(A0, data);
+
+    if (__front_buffer_pos >= *__front_buffer_len)
+        __buffer_swap_required = true;
+    
+    if (__samples_callback != 0) {
+        __samples_next_callback--;
+        if (__samples_next_callback == 0 ) {
+            __callback_due = true;
+            __samples_next_callback = __samples_callback;
+        }
     }
 }
 
-void TC5_Handler (void) __attribute__ ((weak, alias("Audio_Handler")));
+void TC5_Handler (void) __attribute__ ((alias("Audio_Handler")));
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This makes a few changes to how the audio buffers are loaded and played

1. Uses two 512 sample buffers in a double buffered arrangement instead of a shared 1024 sample buffer
2. Callbacks are called from the main thread instead of the IRQ
3. Heap usage has been removed

Limitations:

1. Still uses global variables so multiple AudioZero classes will collide
2. No longer preloads the first buffer so will have a tiny delay to the audio start time after calling play()
3. Calling play() without first calling prepare() is likely to fail randomly